### PR TITLE
Surround modes are flipped

### DIFF
--- a/docs/documentation.json
+++ b/docs/documentation.json
@@ -360,7 +360,7 @@
         "GetEQ": {
           "description": "Get equalizer value",
           "params": {
-            "EQType": "Allowed values `DialogLevel` (bool) / `MusicSurroundLevel` (-15/+15) /  `NightMode` (bool) / `SubGain` (-10/+10) / `SurroundEnable` (bool) / `SurroundLevel` (-15/+15) / `SurroundMode` (0 = full, 1 = ambient)",
+            "EQType": "Allowed values `DialogLevel` (bool) / `MusicSurroundLevel` (-15/+15) /  `NightMode` (bool) / `SubGain` (-10/+10) / `SurroundEnable` (bool) / `SurroundLevel` (-15/+15) / `SurroundMode` (0 = ambient, 1 = full)",
             "CurrentValue": "Booleans return `1` / `0`, rest number as specified"
           },
           "remarks": "Not all EQ types are available on every speaker"
@@ -386,7 +386,7 @@
         "SetEQ": {
           "description": "Set equalizer value for different types",
           "params": {
-            "EQType": "Allowed values `DialogLevel` (bool) / `MusicSurroundLevel` (-15/+15) /  `NightMode` (bool) / `SubGain` (-10/+10) / `SurroundEnable` (bool) / `SurroundLevel` (-15/+15) / `SurroundMode` (0 = full, 1 = ambient)",
+            "EQType": "Allowed values `DialogLevel` (bool) / `MusicSurroundLevel` (-15/+15) /  `NightMode` (bool) / `SubGain` (-10/+10) / `SurroundEnable` (bool) / `SurroundLevel` (-15/+15) / `SurroundMode` (0 = ambient, 1 = full)",
             "DesiredValue": "Booleans required `1` for true or `0` for false, rest number as specified"
           },
           "remarks": "Not supported by all speakers, TV related"

--- a/docs/services/rendering-control.md
+++ b/docs/services/rendering-control.md
@@ -89,7 +89,7 @@ Inputs:
 | parameter | type | description |
 |:----------|:-----|:------------|
 | **InstanceID** | `ui4` | InstanceID should always be `0` |
-| **EQType** | `string` | Allowed values `DialogLevel` (bool) / `MusicSurroundLevel` (-15/+15) /  `NightMode` (bool) / `SubGain` (-10/+10) / `SurroundEnable` (bool) / `SurroundLevel` (-15/+15) / `SurroundMode` (0 = full, 1 = ambient) |
+| **EQType** | `string` | Allowed values `DialogLevel` (bool) / `MusicSurroundLevel` (-15/+15) /  `NightMode` (bool) / `SubGain` (-10/+10) / `SurroundEnable` (bool) / `SurroundLevel` (-15/+15) / `SurroundMode` (0 = ambient, 1 = full) |
 
 Outputs:
 
@@ -488,7 +488,7 @@ Inputs:
 | parameter | type | description |
 |:----------|:-----|:------------|
 | **InstanceID** | `ui4` | InstanceID should always be `0` |
-| **EQType** | `string` | Allowed values `DialogLevel` (bool) / `MusicSurroundLevel` (-15/+15) /  `NightMode` (bool) / `SubGain` (-10/+10) / `SurroundEnable` (bool) / `SurroundLevel` (-15/+15) / `SurroundMode` (0 = full, 1 = ambient) |
+| **EQType** | `string` | Allowed values `DialogLevel` (bool) / `MusicSurroundLevel` (-15/+15) /  `NightMode` (bool) / `SubGain` (-10/+10) / `SurroundEnable` (bool) / `SurroundLevel` (-15/+15) / `SurroundMode` (0 = ambient, 1 = full) |
 | **DesiredValue** | `i2` | Booleans required `1` for true or `0` for false, rest number as specified |
 
 **Remarks** Not supported by all speakers, TV related


### PR DESCRIPTION
# Surround modes are flipped

## Description

The surround modes are flipped. I deduced this based on observed behavior using the API, as well as cross-referencing other libraries (such as [SOCO](https://github.com/SoCo/SoCo/blob/723ee527acb80d84833d91be0dd1a084312f4e10/soco/core.py#L1293))

## Your checklist for this pull request

🚨 Please review the [guidelines for contributing](https://github.com/svrooij/sonos-api-docs/blob/main/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your main!
- [x] Make sure you are making a pull request against the **main branch** (left side). Also you should start *your branch* off *svrooij/sonos-api-docs/main*.
- [x] Check your code additions will fail neither code linting checks nor unit test. (mine sometimes also fail, will probably ignore the lint failures)
- [x] If you changed the **documentation.json** be sure to also [regenerate](https://svrooij.io/sonos-api-docs/developers.html#regenerate-documentation) the services files.
- [x] The `docs/services/index.md` and the `docs/services/*.md` files should not be manually changed, only with the generator.

💔 Thank you!