### PR TITLE
Adding Height Audio As A Modifiable EQ Option

### DIFF
--- a/docs/documentation.json
+++ b/docs/documentation.json
@@ -360,7 +360,7 @@
         "GetEQ": {
           "description": "Get equalizer value",
           "params": {
-            "EQType": "Allowed values `DialogLevel` (bool) / `MusicSurroundLevel` (-15/+15) /  `NightMode` (bool) / `SubGain` (-10/+10) / `SurroundEnable` (bool) / `SurroundLevel` (-15/+15) / `SurroundMode` (0 = ambient, 1 = full)",
+            "EQType": "Allowed values `DialogLevel` (bool) / `MusicSurroundLevel` (-15/+15) /  `NightMode` (bool) / `SubGain` (-10/+10) / `SurroundEnable` (bool) / `SurroundLevel` (-15/+15) / `SurroundMode` (0 = ambient, 1 = full) / `HeightChannelLevel` (-10/+10)",
             "CurrentValue": "Booleans return `1` / `0`, rest number as specified"
           },
           "remarks": "Not all EQ types are available on every speaker"
@@ -386,7 +386,7 @@
         "SetEQ": {
           "description": "Set equalizer value for different types",
           "params": {
-            "EQType": "Allowed values `DialogLevel` (bool) / `MusicSurroundLevel` (-15/+15) /  `NightMode` (bool) / `SubGain` (-10/+10) / `SurroundEnable` (bool) / `SurroundLevel` (-15/+15) / `SurroundMode` (0 = ambient, 1 = full)",
+            "EQType": "Allowed values `DialogLevel` (bool) / `MusicSurroundLevel` (-15/+15) /  `NightMode` (bool) / `SubGain` (-10/+10) / `SurroundEnable` (bool) / `SurroundLevel` (-15/+15) / `SurroundMode` (0 = ambient, 1 = full) / `HeightChannelLevel` (-10/+10)",
             "DesiredValue": "Booleans required `1` for true or `0` for false, rest number as specified"
           },
           "remarks": "Not supported by all speakers, TV related"

--- a/docs/services/rendering-control.md
+++ b/docs/services/rendering-control.md
@@ -89,7 +89,7 @@ Inputs:
 | parameter | type | description |
 |:----------|:-----|:------------|
 | **InstanceID** | `ui4` | InstanceID should always be `0` |
-| **EQType** | `string` | Allowed values `DialogLevel` (bool) / `MusicSurroundLevel` (-15/+15) /  `NightMode` (bool) / `SubGain` (-10/+10) / `SurroundEnable` (bool) / `SurroundLevel` (-15/+15) / `SurroundMode` (0 = ambient, 1 = full) |
+| **EQType** | `string` | Allowed values `DialogLevel` (bool) / `MusicSurroundLevel` (-15/+15) /  `NightMode` (bool) / `SubGain` (-10/+10) / `SurroundEnable` (bool) / `SurroundLevel` (-15/+15) / `SurroundMode` (0 = ambient, 1 = full) / `HeightChannelLevel` (-10/+10) |
 
 Outputs:
 
@@ -488,7 +488,7 @@ Inputs:
 | parameter | type | description |
 |:----------|:-----|:------------|
 | **InstanceID** | `ui4` | InstanceID should always be `0` |
-| **EQType** | `string` | Allowed values `DialogLevel` (bool) / `MusicSurroundLevel` (-15/+15) /  `NightMode` (bool) / `SubGain` (-10/+10) / `SurroundEnable` (bool) / `SurroundLevel` (-15/+15) / `SurroundMode` (0 = ambient, 1 = full) |
+| **EQType** | `string` | Allowed values `DialogLevel` (bool) / `MusicSurroundLevel` (-15/+15) /  `NightMode` (bool) / `SubGain` (-10/+10) / `SurroundEnable` (bool) / `SurroundLevel` (-15/+15) / `SurroundMode` (0 = ambient, 1 = full) / `HeightChannelLevel` (-10/+10) |
 | **DesiredValue** | `i2` | Booleans required `1` for true or `0` for false, rest number as specified |
 
 **Remarks** Not supported by all speakers, TV related


### PR DESCRIPTION
# Adding Height Audio As A Modifiable EQ Option

## Description

Add the `HeightChannelLevel` EQ type, allowing for the height audio to be retrieved and set.

I was able to confirm that `HeightChannelLevel` is a valid EQ type using Wireshark (along with my Arc). When I would modify the height audio using the official iOS app, I saw the following POSTed to `/MediaRenderer/RenderingControl/Control`

```xml
<s:Envelope
	xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"
        s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
	<s:Body>
		<u:SetEQ
			xmlns:u="urn:schemas-upnp-org:service:RenderingControl:1">
			<InstanceID>
                    0
                    </InstanceID>
			<EQType>
                    HeightChannelLevel
                    </EQType>
			<DesiredValue>
                    4
                    </DesiredValue>
		</u:SetEQ>
	</s:Body>
</s:Envelope>
```

## Your checklist for this pull request

🚨 Please review the [guidelines for contributing](https://github.com/svrooij/sonos-api-docs/blob/main/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your main!
- [x] Make sure you are making a pull request against the **main branch** (left side). Also you should start *your branch* off *svrooij/sonos-api-docs/main*.
- [x] Check your code additions will fail neither code linting checks nor unit test. (mine sometimes also fail, will probably ignore the lint failures)
- [x] If you changed the **documentation.json** be sure to also [regenerate](https://svrooij.io/sonos-api-docs/developers.html#regenerate-documentation) the services files.
- [x] The `docs/services/index.md` and the `docs/services/*.md` files should not be manually changed, only with the generator.

💔 Thank you!