### PR TITLE
fix: Additional event properties in generator

### DIFF
--- a/docs/documentation.json
+++ b/docs/documentation.json
@@ -400,7 +400,13 @@
             "DesiredTreble": "between -10 and 10"
           }
         }
-      }
+      },
+      "variables": [
+        {
+          "name": "HeightChannelLevel",
+          "dataType": "ui4"
+        }
+      ]
     },
     "SystemPropertiesService": {
       "description": "Manage system-wide settings, mainly account stuff",

--- a/docs/schema/documentation.json
+++ b/docs/schema/documentation.json
@@ -22,6 +22,13 @@
           "items": {
             "$ref": "#/definitions/SonosCustomError"
           }
+        },
+        "variables": {
+          "title": "Service variables",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SonosServiceVariable"
+          }
         }
       },
       "type": "object",
@@ -72,6 +79,26 @@
       },
       "type": "object",
       "required": ["code", "description"]
+    },
+    "SonosServiceVariable": {
+      "title": "Service variable",
+      "description": "Used for variable description and additional event properties",
+      "type": "object",
+      "properties": {
+        "name": {
+          "title": "Name of the event",
+          "type": "string"
+        },
+        "dataType": {
+          "type": "string",
+          "enum": ["string", "boolean", "ui2", "i4", "ui4"]
+        },
+        "description": {
+          "type":"string",
+          "title": "Optional description"
+        }
+      },
+      "required": ["name", "dataType"]
     }
   },
   "properties": {

--- a/docs/services/alarm-clock.md
+++ b/docs/services/alarm-clock.md
@@ -22,7 +22,7 @@ The AlarmClock service is available on these models: `Sonos Play:1 (S1) S2` / `S
 |:-----|:------|
 | **Control URL** | `http://192.168.x.x:1400/AlarmClock/Control` |
 | **Event subscription URL** | `http://192.168.x.x:1400/AlarmClock/Event` |
-| **Discovery url** | `http://192.168.x.x:1400/xml/AlarmClock1.xml` |
+| **Discovery URL** | `http://192.168.x.x:1400/xml/AlarmClock1.xml` |
 | **Service ID** | `urn:upnp-org:serviceId:AlarmClock` |
 | **Service type** | `urn:schemas-upnp-org:service:AlarmClock:1` |
 

--- a/docs/services/audio-in.md
+++ b/docs/services/audio-in.md
@@ -22,7 +22,7 @@ The AudioIn service is available on these models: `Sonos Play:5 (S6) S2`.
 |:-----|:------|
 | **Control URL** | `http://192.168.x.x:1400/AudioIn/Control` |
 | **Event subscription URL** | `http://192.168.x.x:1400/AudioIn/Event` |
-| **Discovery url** | `http://192.168.x.x:1400/xml/AudioIn1.xml` |
+| **Discovery URL** | `http://192.168.x.x:1400/xml/AudioIn1.xml` |
 | **Service ID** | `urn:upnp-org:serviceId:AudioIn` |
 | **Service type** | `urn:schemas-upnp-org:service:AudioIn:1` |
 

--- a/docs/services/av-transport.md
+++ b/docs/services/av-transport.md
@@ -22,7 +22,7 @@ The AVTransport service is available on these models: `Sonos Play:1 (S1) S2` / `
 |:-----|:------|
 | **Control URL** | `http://192.168.x.x:1400/MediaRenderer/AVTransport/Control` |
 | **Event subscription URL** | `http://192.168.x.x:1400/MediaRenderer/AVTransport/Event` |
-| **Discovery url** | `http://192.168.x.x:1400/xml/AVTransport1.xml` |
+| **Discovery URL** | `http://192.168.x.x:1400/xml/AVTransport1.xml` |
 | **Service ID** | `urn:upnp-org:serviceId:AVTransport` |
 | **Service type** | `urn:schemas-upnp-org:service:AVTransport:1` |
 

--- a/docs/services/connection-manager.md
+++ b/docs/services/connection-manager.md
@@ -22,7 +22,7 @@ The ConnectionManager service is available on these models: `Sonos Play:1 (S1) S
 |:-----|:------|
 | **Control URL** | `http://192.168.x.x:1400/MediaRenderer/ConnectionManager/Control` |
 | **Event subscription URL** | `http://192.168.x.x:1400/MediaRenderer/ConnectionManager/Event` |
-| **Discovery url** | `http://192.168.x.x:1400/xml/ConnectionManager1.xml` |
+| **Discovery URL** | `http://192.168.x.x:1400/xml/ConnectionManager1.xml` |
 | **Service ID** | `urn:upnp-org:serviceId:ConnectionManager` |
 | **Service type** | `urn:schemas-upnp-org:service:ConnectionManager:1` |
 

--- a/docs/services/content-directory.md
+++ b/docs/services/content-directory.md
@@ -22,7 +22,7 @@ The ContentDirectory service is available on these models: `Sonos Play:1 (S1) S2
 |:-----|:------|
 | **Control URL** | `http://192.168.x.x:1400/MediaServer/ContentDirectory/Control` |
 | **Event subscription URL** | `http://192.168.x.x:1400/MediaServer/ContentDirectory/Event` |
-| **Discovery url** | `http://192.168.x.x:1400/xml/ContentDirectory1.xml` |
+| **Discovery URL** | `http://192.168.x.x:1400/xml/ContentDirectory1.xml` |
 | **Service ID** | `urn:upnp-org:serviceId:ContentDirectory` |
 | **Service type** | `urn:schemas-upnp-org:service:ContentDirectory:1` |
 

--- a/docs/services/device-properties.md
+++ b/docs/services/device-properties.md
@@ -22,7 +22,7 @@ The DeviceProperties service is available on these models: `Sonos Play:1 (S1) S2
 |:-----|:------|
 | **Control URL** | `http://192.168.x.x:1400/DeviceProperties/Control` |
 | **Event subscription URL** | `http://192.168.x.x:1400/DeviceProperties/Event` |
-| **Discovery url** | `http://192.168.x.x:1400/xml/DeviceProperties1.xml` |
+| **Discovery URL** | `http://192.168.x.x:1400/xml/DeviceProperties1.xml` |
 | **Service ID** | `urn:upnp-org:serviceId:DeviceProperties` |
 | **Service type** | `urn:schemas-upnp-org:service:DeviceProperties:1` |
 

--- a/docs/services/group-management.md
+++ b/docs/services/group-management.md
@@ -22,7 +22,7 @@ The GroupManagement service is available on these models: `Sonos Play:1 (S1) S2`
 |:-----|:------|
 | **Control URL** | `http://192.168.x.x:1400/GroupManagement/Control` |
 | **Event subscription URL** | `http://192.168.x.x:1400/GroupManagement/Event` |
-| **Discovery url** | `http://192.168.x.x:1400/xml/GroupManagement1.xml` |
+| **Discovery URL** | `http://192.168.x.x:1400/xml/GroupManagement1.xml` |
 | **Service ID** | `urn:upnp-org:serviceId:GroupManagement` |
 | **Service type** | `urn:schemas-upnp-org:service:GroupManagement:1` |
 

--- a/docs/services/group-rendering-control.md
+++ b/docs/services/group-rendering-control.md
@@ -22,7 +22,7 @@ The GroupRenderingControl service is available on these models: `Sonos Play:1 (S
 |:-----|:------|
 | **Control URL** | `http://192.168.x.x:1400/MediaRenderer/GroupRenderingControl/Control` |
 | **Event subscription URL** | `http://192.168.x.x:1400/MediaRenderer/GroupRenderingControl/Event` |
-| **Discovery url** | `http://192.168.x.x:1400/xml/GroupRenderingControl1.xml` |
+| **Discovery URL** | `http://192.168.x.x:1400/xml/GroupRenderingControl1.xml` |
 | **Service ID** | `urn:upnp-org:serviceId:GroupRenderingControl` |
 | **Service type** | `urn:schemas-upnp-org:service:GroupRenderingControl:1` |
 

--- a/docs/services/ht-control.md
+++ b/docs/services/ht-control.md
@@ -22,7 +22,7 @@ The HTControl service is available on these models: `Sonos Beam (S14) S2` / `Son
 |:-----|:------|
 | **Control URL** | `http://192.168.x.x:1400/HTControl/Control` |
 | **Event subscription URL** | `http://192.168.x.x:1400/HTControl/Event` |
-| **Discovery url** | `http://192.168.x.x:1400/xml/HTControl1.xml` |
+| **Discovery URL** | `http://192.168.x.x:1400/xml/HTControl1.xml` |
 | **Service ID** | `urn:upnp-org:serviceId:HTControl` |
 | **Service type** | `urn:schemas-upnp-org:service:HTControl:1` |
 

--- a/docs/services/music-services.md
+++ b/docs/services/music-services.md
@@ -22,7 +22,7 @@ The MusicServices service is available on these models: `Sonos Play:1 (S1) S2` /
 |:-----|:------|
 | **Control URL** | `http://192.168.x.x:1400/MusicServices/Control` |
 | **Event subscription URL** | `http://192.168.x.x:1400/MusicServices/Event` |
-| **Discovery url** | `http://192.168.x.x:1400/xml/MusicServices1.xml` |
+| **Discovery URL** | `http://192.168.x.x:1400/xml/MusicServices1.xml` |
 | **Service ID** | `urn:upnp-org:serviceId:MusicServices` |
 | **Service type** | `urn:schemas-upnp-org:service:MusicServices:1` |
 

--- a/docs/services/q-play.md
+++ b/docs/services/q-play.md
@@ -22,7 +22,7 @@ The QPlay service is available on these models: `Sonos Play:1 (S1) S2` / `Sonos 
 |:-----|:------|
 | **Control URL** | `http://192.168.x.x:1400/QPlay/Control` |
 | **Event subscription URL** | `http://192.168.x.x:1400/QPlay/Event` |
-| **Discovery url** | `http://192.168.x.x:1400/xml/QPlay1.xml` |
+| **Discovery URL** | `http://192.168.x.x:1400/xml/QPlay1.xml` |
 | **Service ID** | `urn:tencent-com:serviceId:QPlay` |
 | **Service type** | `urn:schemas-tencent-com:service:QPlay:1` |
 

--- a/docs/services/queue.md
+++ b/docs/services/queue.md
@@ -22,7 +22,7 @@ The Queue service is available on these models: `Sonos Play:1 (S1) S2` / `Sonos 
 |:-----|:------|
 | **Control URL** | `http://192.168.x.x:1400/MediaRenderer/Queue/Control` |
 | **Event subscription URL** | `http://192.168.x.x:1400/MediaRenderer/Queue/Event` |
-| **Discovery url** | `http://192.168.x.x:1400/xml/Queue1.xml` |
+| **Discovery URL** | `http://192.168.x.x:1400/xml/Queue1.xml` |
 | **Service ID** | `urn:sonos-com:serviceId:Queue` |
 | **Service type** | `urn:schemas-sonos-com:service:Queue:1` |
 

--- a/docs/services/rendering-control.md
+++ b/docs/services/rendering-control.md
@@ -704,6 +704,7 @@ Timeout: Second-3600
 | DialogLevel |  | `string` |  |
 | EQValue |  | `i2` |  |
 | HeadphoneConnected |  | `boolean` |  `1` for true and `0` for false  |
+| HeightChannelLevel | ✔ | `ui4` |  |
 | LastChange | ✔ | `string` |  |
 | Loudness |  | `boolean` |  `1` for true and `0` for false  |
 | MusicSurroundLevel |  | `string` |  |

--- a/docs/services/rendering-control.md
+++ b/docs/services/rendering-control.md
@@ -22,7 +22,7 @@ The RenderingControl service is available on these models: `Sonos Play:1 (S1) S2
 |:-----|:------|
 | **Control URL** | `http://192.168.x.x:1400/MediaRenderer/RenderingControl/Control` |
 | **Event subscription URL** | `http://192.168.x.x:1400/MediaRenderer/RenderingControl/Event` |
-| **Discovery url** | `http://192.168.x.x:1400/xml/RenderingControl1.xml` |
+| **Discovery URL** | `http://192.168.x.x:1400/xml/RenderingControl1.xml` |
 | **Service ID** | `urn:upnp-org:serviceId:RenderingControl` |
 | **Service type** | `urn:schemas-upnp-org:service:RenderingControl:1` |
 

--- a/docs/services/system-properties.md
+++ b/docs/services/system-properties.md
@@ -22,7 +22,7 @@ The SystemProperties service is available on these models: `Sonos Play:1 (S1) S2
 |:-----|:------|
 | **Control URL** | `http://192.168.x.x:1400/SystemProperties/Control` |
 | **Event subscription URL** | `http://192.168.x.x:1400/SystemProperties/Event` |
-| **Discovery url** | `http://192.168.x.x:1400/xml/SystemProperties1.xml` |
+| **Discovery URL** | `http://192.168.x.x:1400/xml/SystemProperties1.xml` |
 | **Service ID** | `urn:upnp-org:serviceId:SystemProperties` |
 | **Service type** | `urn:schemas-upnp-org:service:SystemProperties:1` |
 

--- a/docs/services/virtual-line-in.md
+++ b/docs/services/virtual-line-in.md
@@ -20,7 +20,7 @@ The VirtualLineIn service is available on these models: `Sonos Play:1 (S1) S2` /
 |:-----|:------|
 | **Control URL** | `http://192.168.x.x:1400/MediaRenderer/VirtualLineIn/Control` |
 | **Event subscription URL** | `http://192.168.x.x:1400/MediaRenderer/VirtualLineIn/Event` |
-| **Discovery url** | `http://192.168.x.x:1400/xml/VirtualLineIn1.xml` |
+| **Discovery URL** | `http://192.168.x.x:1400/xml/VirtualLineIn1.xml` |
 | **Service ID** | `urn:upnp-org:serviceId:VirtualLineIn` |
 | **Service type** | `urn:schemas-upnp-org:service:VirtualLineIn:1` |
 

--- a/docs/services/zone-group-topology.md
+++ b/docs/services/zone-group-topology.md
@@ -22,7 +22,7 @@ The ZoneGroupTopology service is available on these models: `Sonos Play:1 (S1) S
 |:-----|:------|
 | **Control URL** | `http://192.168.x.x:1400/ZoneGroupTopology/Control` |
 | **Event subscription URL** | `http://192.168.x.x:1400/ZoneGroupTopology/Event` |
-| **Discovery url** | `http://192.168.x.x:1400/xml/ZoneGroupTopology1.xml` |
+| **Discovery URL** | `http://192.168.x.x:1400/xml/ZoneGroupTopology1.xml` |
 | **Service ID** | `urn:upnp-org:serviceId:ZoneGroupTopology` |
 | **Service type** | `urn:schemas-upnp-org:service:ZoneGroupTopology:1` |
 

--- a/generator/sonos-docs/src/commands/combine.ts
+++ b/generator/sonos-docs/src/commands/combine.ts
@@ -237,6 +237,32 @@ export default class Combine extends Command {
           }
         })
       }
+
+      if (docs?.variables) {
+        if (!s.stateVariables) {
+          s.stateVariables = [];
+        }
+        docs.variables.forEach(p => {
+          p.sendEvents = true;
+          // @ts-ignore
+          const index = s.stateVariables.findIndex(v => v.name === p.name);
+          if (index > -1) {
+            // @ts-ignore
+            s.stateVariables[index].description = p.description;
+            // @ts-ignore
+            s.stateVariables[index].dataType = p.dataType;
+            if (p.allowedValues) {
+              // @ts-ignore
+              s.stateVariables[index].allowedValues = p.allowedValues;
+            }
+            
+          } else {
+            s.stateVariables?.push(p);
+          }
+        });
+        
+        
+      }
     })
     combinedServices.services = combinedServices.services.sort((a: SonosService, b: SonosService) => a.name.localeCompare(b.name))
     cli.action.stop()

--- a/generator/sonos-docs/src/models/sonos-service-documentation.ts
+++ b/generator/sonos-docs/src/models/sonos-service-documentation.ts
@@ -1,4 +1,5 @@
 import SonosServiceError from './sonos-service-error';
+import SonosStateVariable from './sonos-state-variable';
 
 export interface SonosServicesDocumentation {
   services: { [key: string]: SonosServiceDocumentation };
@@ -11,6 +12,7 @@ export interface SonosServiceDocumentation {
   actions?: { [key: string]: SonosServiceDocumentationAction };
   customTypes?: { [key: string]: { [key: string]: string } };
   errors?: SonosServiceError[];
+  variables?: SonosStateVariable[];
 }
 
 export interface SonosServiceDocumentationAction {

--- a/generator/sonos-docs/templates/docs/service.hbs
+++ b/generator/sonos-docs/templates/docs/service.hbs
@@ -26,7 +26,7 @@ The {{name}} service is available on these models: {{#each deviceInfo}}`{{modelD
 |:-----|:------|
 | **Control URL** | `http://192.168.x.x:1400{{controlURL}}` |
 | **Event subscription URL** | `http://192.168.x.x:1400{{eventSubURL}}` |
-| **Discovery url** | `http://192.168.x.x:1400{{discoveryUri}}` |
+| **Discovery URL** | `http://192.168.x.x:1400{{discoveryUri}}` |
 | **Service ID** | `{{serviceId}}` |
 | **Service type** | `{{serviceType}}` |
 


### PR DESCRIPTION
Fixed #38

# Additional event properties in generator

## Description

@jkossis discovered that some sonos speakers send event variables not in the service discovery.

## Your checklist for this pull request

🚨 Please review the [guidelines for contributing](https://github.com/svrooij/sonos-api-docs/blob/main/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your main!
- [x] Make sure you are making a pull request against the **main branch** (left side). Also you should start *your branch* off *svrooij/sonos-api-docs/main*.
- [x] Check your code additions will fail neither code linting checks nor unit test. (mine sometimes also fail, will probably ignore the lint failures)
- [x] If you changed the **documentation.json** be sure to also [regenerate](https://svrooij.io/sonos-api-docs/developers.html#regenerate-documentation) the services files.
- [x] The `docs/services/index.md` and the `docs/services/*.md` files should not be manually changed, only with the generator.

💔 Thank you!