### PR TITLE
Add support for snake case

### DIFF
--- a/docs/developers.md
+++ b/docs/developers.md
@@ -135,7 +135,7 @@ The generator uses [Handlebars](https://handlebarsjs.com/) templates. A template
 The template.json file gives some basic information about the template, the author of that template and which files to use.
 
 1. File usage `index`, will use the data from intermediate.json as input to produce **one file**.
-2. File usage `service`, will use the data from each service to produce **one file per service**, be sure to use `{snService}` or `{service}` in the **outputFile**.
+2. File usage `service`, will use the data from each service to produce **one file per service**, be sure to use `{kebabService}`, `{snakeService}`, or `{service}` in the **outputFile**.
 
 Be sure to check out the [docs template](https://github.com/svrooij/sonos-api-docs/tree/main/generator/sonos-docs/templates/docs) to get started. Or the [ts template](https://github.com/svrooij/node-sonos-ts/tree/master/.generator/ts), which is used to generate [Sonos typescript](https://sonos-ts.svrooij.io/).
 

--- a/docs/schema/template.json
+++ b/docs/schema/template.json
@@ -10,7 +10,7 @@
         },
         "outputFile": {
           "title": "Output filename",
-          "description": "How to output the file(s), '{service}' is replaced by the serviceName, '{snService}' is replaced by snakecase service name",
+          "description": "How to output the file(s), '{service}' is replaced by the serviceName, '{kebabService}' is replaced by kebabcase service name, '{snakeService}' is replaced by snakecase service name",
           "type": "string"
         },
         "usage": {

--- a/generator/sonos-docs/src/commands/generate.ts
+++ b/generator/sonos-docs/src/commands/generate.ts
@@ -178,7 +178,7 @@ export default class Generate extends Command {
     // Set relatedStateVariables to correct value.
     const intermediate = JSON.parse(fs.readFileSync(intermediateFile).toString()) as ExtendedSonosDescription
     intermediate.services.forEach(service => {
-      service.kebabName = StringHelper.initCapsToKebab(service.name.replace('AV', 'Av').replace('HT', 'Ht'))
+      service.kebabName = StringHelper.initCapsToKebab(service.name)
       if (typeof (service.stateVariables) !== undefined) {
         // Replace datatypes as specified in the template
         if (dataTypes !== undefined) {

--- a/generator/sonos-docs/src/commands/generate.ts
+++ b/generator/sonos-docs/src/commands/generate.ts
@@ -114,7 +114,8 @@ export default class Generate extends Command {
         const template = this.getHandlebarTemplate<SonosService>(outputTemplate.folder, t.file)
         deviceDescription.services.forEach(s => {
           const outputfile = path.join(outputBase, t.outputFile
-            .replace('{snService}', s.kebabName ?? '')
+            .replace('{snService}', s.kebabName ?? '') // duplicates `kebabService` for backwards compatibility
+            .replace('{kebabService}', s.kebabName ?? '')
             .replace('{snakeService}', StringHelper.initCapsToSnake(s.name) ?? '')
             .replace('{service}', s.name))
           const folder = path.dirname(outputfile)

--- a/generator/sonos-docs/src/commands/generate.ts
+++ b/generator/sonos-docs/src/commands/generate.ts
@@ -59,7 +59,14 @@ export default class Generate extends Command {
     // {{kebab var}} for kebab case
     handlebars.registerHelper('kebab', (input: any) => {
       if (typeof input === 'string') {
-        return StringHelper.camelToKebab(input)
+        return StringHelper.initCapsToKebab(input)
+      }
+      return input
+    })
+    // {{snake var}} for snake case
+    handlebars.registerHelper('snake', (input: any) => {
+      if (typeof input === 'string') {
+        return StringHelper.initCapsToSnake(input)
       }
       return input
     })
@@ -106,7 +113,10 @@ export default class Generate extends Command {
         cli.action.start(`Creating services '${t.outputFile}' from template '${t.file}'`)
         const template = this.getHandlebarTemplate<SonosService>(outputTemplate.folder, t.file)
         deviceDescription.services.forEach(s => {
-          const outputfile = path.join(outputBase, t.outputFile.replace('{snService}', s.kebabName ?? '').replace('{service}', s.name))
+          const outputfile = path.join(outputBase, t.outputFile
+            .replace('{snService}', s.kebabName ?? '')
+            .replace('{snakeService}', StringHelper.initCapsToSnake(s.name) ?? '')
+            .replace('{service}', s.name))
           const folder = path.dirname(outputfile)
           if (!fs.existsSync(folder)) {
             fs.mkdirSync(folder, {recursive: true})
@@ -167,7 +177,7 @@ export default class Generate extends Command {
     // Set relatedStateVariables to correct value.
     const intermediate = JSON.parse(fs.readFileSync(intermediateFile).toString()) as ExtendedSonosDescription
     intermediate.services.forEach(service => {
-      service.kebabName = StringHelper.camelToKebab(service.name.replace('AV', 'Av').replace('HT', 'Ht'))
+      service.kebabName = StringHelper.initCapsToKebab(service.name.replace('AV', 'Av').replace('HT', 'Ht'))
       if (typeof (service.stateVariables) !== undefined) {
         // Replace datatypes as specified in the template
         if (dataTypes !== undefined) {

--- a/generator/sonos-docs/src/commands/generate.ts
+++ b/generator/sonos-docs/src/commands/generate.ts
@@ -98,7 +98,7 @@ export default class Generate extends Command {
         throw new handlebars.Exception('2nd parameter has to be a string')
       }
 
-      return input?.endsWith(endsWith) == true;
+      return input?.endsWith(endsWith)
     })
 
     outputTemplate?.files.forEach(t => {
@@ -114,10 +114,10 @@ export default class Generate extends Command {
         const template = this.getHandlebarTemplate<SonosService>(outputTemplate.folder, t.file)
         deviceDescription.services.forEach(s => {
           const outputfile = path.join(outputBase, t.outputFile
-            .replace('{snService}', s.kebabName ?? '') // duplicates `kebabService` for backwards compatibility
-            .replace('{kebabService}', s.kebabName ?? '')
-            .replace('{snakeService}', StringHelper.initCapsToSnake(s.name) ?? '')
-            .replace('{service}', s.name))
+          .replace('{snService}', s.kebabName ?? '') // duplicates `kebabService` for backwards compatibility
+          .replace('{kebabService}', s.kebabName ?? '')
+          .replace('{snakeService}', StringHelper.initCapsToSnake(s.name) ?? '')
+          .replace('{service}', s.name))
           const folder = path.dirname(outputfile)
           if (!fs.existsSync(folder)) {
             fs.mkdirSync(folder, {recursive: true})

--- a/generator/sonos-docs/src/helpers/string-helper.ts
+++ b/generator/sonos-docs/src/helpers/string-helper.ts
@@ -1,9 +1,9 @@
 export default class StringHelper {
   public static initCapsToKebab(input: string): string {
-    return input.replace(/([a-z0-9])([A-Z]+)/g, '$1-$2').toLowerCase();
+    return `${input[0].toLowerCase()}${input.slice(1)}`.replace(/([a-z0-9])([A-Z]+)/g, '$1-$2').toLowerCase();
   }
 
   public static initCapsToSnake(input: string): string {
-    return input.replace(/([a-z0-9])([A-Z]+)/g, '$1_$2').toLowerCase();
+    return `${input[0].toLowerCase()}${input.slice(1)}`.replace(/([a-z0-9])([A-Z]+)/g, '$1_$2').toLowerCase();
   }
 }

--- a/generator/sonos-docs/src/helpers/string-helper.ts
+++ b/generator/sonos-docs/src/helpers/string-helper.ts
@@ -1,9 +1,18 @@
 export default class StringHelper {
   public static initCapsToKebab(input: string): string {
-    return `${input[0].toLowerCase()}${input.slice(1)}`.replace(/([a-z0-9])([A-Z]+)/g, '$1-$2').toLowerCase();
+    return StringHelper.replaceInitCapLetters(input).replace(/([a-z0-9])([A-Z]+)/g, '$1-$2').toLowerCase()
   }
 
   public static initCapsToSnake(input: string): string {
-    return `${input[0].toLowerCase()}${input.slice(1)}`.replace(/([a-z0-9])([A-Z]+)/g, '$1_$2').toLowerCase();
+    return StringHelper.replaceInitCapLetters(input).replace(/([a-z0-9])([A-Z]+)/g, '$1_$2').toLowerCase()
+  }
+
+  static replaceInitCapLetters(input: string): string {
+    // Looking for leading capital letters and lowercase all but the last one. For example: 'AVTransport' -> 'avTransport'
+    const m = input.match(/[A-Z]+/)
+    if (m === null || m[0].length === input.length) {
+      return input
+    }
+    return input.slice(0, m[0].length - 1).toLowerCase() + input.slice(m[0].length - 1)
   }
 }

--- a/generator/sonos-docs/src/helpers/string-helper.ts
+++ b/generator/sonos-docs/src/helpers/string-helper.ts
@@ -1,5 +1,9 @@
 export default class StringHelper {
-  public static camelToKebab(input: string): string {
-    return `${input[0].toLowerCase()}${input.slice(1)}`.replace(/([a-z0-9]|(?=[A-Z]))([A-Z])/g, '$1-$2').toLowerCase();
+  public static initCapsToKebab(input: string): string {
+    return input.replace(/([a-z0-9])([A-Z]+)/g, '$1-$2').toLowerCase();
+  }
+
+  public static initCapsToSnake(input: string): string {
+    return input.replace(/([a-z0-9])([A-Z]+)/g, '$1_$2').toLowerCase();
   }
 }

--- a/generator/sonos-docs/templates/docs/template.json
+++ b/generator/sonos-docs/templates/docs/template.json
@@ -9,7 +9,7 @@
   "files": [
     {
       "file": "service.hbs",
-      "outputFile": "services/{snService}.md",
+      "outputFile": "services/{kebabService}.md",
       "usage":"service"
     },
     {

--- a/generator/sonos-docs/templates/node/template.json
+++ b/generator/sonos-docs/templates/node/template.json
@@ -10,7 +10,7 @@
   "files": [
     {
       "file": "service.hbs",
-      "outputFile": "lib/services/{snService}.service.js",
+      "outputFile": "lib/services/{kebabService}.service.js",
       "usage":"service"
     }
   ],


### PR DESCRIPTION
## Description

This PR
* Adds snake case support to the generator, i.e. `{{snake name}}`, for use in languages like Rust that expect `snake_case` file and variable names
* Adds `snakeService` for use in the template configuration file (similar to existing `snService`)
* Adds `kebabService` in favor of `snService` for clarity (`snService` kept around for backward compatiblity). All usage and reference to `snService` was replaced though.

See example usage for Rust in this [template](https://github.com/andrewwdye/sonos-cli/tree/main/template) and [generated files](https://github.com/andrewwdye/sonos-cli/tree/main/src/sonos/gen).

## Your checklist for this pull request

🚨 Please review the [guidelines for contributing](https://github.com/svrooij/sonos-api-docs/blob/main/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your main!
- [x] Make sure you are making a pull request against the **main branch** (left side). Also you should start *your branch* off *svrooij/sonos-api-docs/main*.
- [x] Check your code additions will fail neither code linting checks nor unit test. (mine sometimes also fail, will probably ignore the lint failures)
- [x] If you changed the **documentation.json** be sure to also [regenerate](https://sonos.svrooij.io/developers.html#regenerate-documentation) the services files.
- [x] The `docs/services/index.md` and the `docs/services/*.md` files should not be manually changed, only with the generator.

💔 Thank you!